### PR TITLE
Show and switch to a window instead of a session

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ set -g @session-wizard-mode "full-path"
 By default, `tmux-session-wizard` gives you a list of open sessions (hence the name). An alternative is that it gives you a list of _windows_ to choose from. This can be turned on using the setting `@session-wizard-windows`. Add this line to your `.tmux.conf` to enable this behaviour:
 
 ```tmux
-set -g @session-wizard-windows on
+set -g @session-wizard-windows on # default is off
 ```
 
 ### (Optional) Using the script outside of tmux

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ To customise the way session names are created, use `@session-wizard-mode` optio
 set -g @session-wizard-mode "full-path"
 ```
 
+By default, `tmux-session-wizard` gives you a list of open sessions (hence the name). An alternative is that it gives you a list of _windows_ to choose, configurable using the setting `@session-wizard-windows`. Add this line to your `.tmux.conf` to enable this behaviour:
+
+```tmux
+set -g @session-wizard-windows on
+```
+
 ### (Optional) Using the script outside of tmux
 
 **Note:** you'll need to check the path of your tpm plugins. It may be `~/.tmux/plugins` or `~/.config/tmux/plugins` depending on where your `tmux.conf` is located.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hit `prefix + I` to fetch the plugin and source it. That's it!
 
 Clone the repo:
 
-    $ git clone https://github.com/27medkamal/tmux-session-wizard ~/clone/path
+    git clone https://github.com/27medkamal/tmux-session-wizard ~/clone/path
 
 Add this line to the bottom of `.tmux.conf`:
 
@@ -73,7 +73,7 @@ To customise the way session names are created, use `@session-wizard-mode` optio
 set -g @session-wizard-mode "full-path"
 ```
 
-By default, `tmux-session-wizard` gives you a list of open sessions (hence the name). An alternative is that it gives you a list of _windows_ to choose, configurable using the setting `@session-wizard-windows`. Add this line to your `.tmux.conf` to enable this behaviour:
+By default, `tmux-session-wizard` gives you a list of open sessions (hence the name). An alternative is that it gives you a list of _windows_ to choose from. This can be turned on using the setting `@session-wizard-windows`. Add this line to your `.tmux.conf` to enable this behaviour:
 
 ```tmux
 set -g @session-wizard-windows on

--- a/bin/t
+++ b/bin/t
@@ -40,7 +40,7 @@ fi
 
 # Get or create session
 if [[ $RESULT == *":"* ]]; then
-  # RESULT comes from list-sessions
+  # RESULT comes from list-sessions or list-windows
   SESSION=$(echo $RESULT | awk '{print $1}')
   SESSION=${SESSION//:/}
   if [ "$SELECT_WINDOW" == "on" ]; then

--- a/bin/t
+++ b/bin/t
@@ -21,7 +21,8 @@ else
     RESULT=$(tmux list-sessions -F "#{session_last_attached} #{session_name}: #{session_windows} window(s)\
 #{?session_grouped, (group ,}#{session_group}#{?session_grouped,),}#{?session_attached, (attached),}")
   fi
-  RESULT=$( (echo "$RESULT" |
+  RESULT=$( (
+    echo "$RESULT" |
       sort -r | (if [ -n "$TMUX" ]; then grep -v " $(tmux display-message -p '#S'):"; else cat; fi) | cut -d' ' -f2-
     zoxide query -l | sed -e "$HOME_REPLACER"
   ) | $(__fzfcmd) --reverse --print-query | tail -n 1)
@@ -83,6 +84,6 @@ else
   tmux switch-client -t "$SESSION"
 fi
 
-if [ ! -z "$WINDOW" ]; then
+if [ -n "$WINDOW" ]; then
   tmux select-window -t "$SESSION:$WINDOW"
 fi

--- a/bin/t
+++ b/bin/t
@@ -7,10 +7,10 @@ source "$CURRENT_DIR/../src/helpers.sh"
 # If no argument is given, a combination of existing sessions and a zoxide query will be displayed in a FZF
 
 # Parse optional argument
-if [ "$1" ]; then
+if [ "$*" ]; then
   # Argument is given
   eval "$(zoxide init bash)"
-  RESULT=$(z $@ && pwd)
+  RESULT=$(z "$*" && pwd)
 else
   # No argument is given. Use FZF
   SELECT_WINDOW=$(get_tmux_option "@session-wizard-windows" "off")
@@ -41,7 +41,7 @@ fi
 # Get or create session
 if [[ $RESULT == *":"* ]]; then
   # RESULT comes from list-sessions or list-windows
-  SESSION=$(echo $RESULT | awk '{print $1}')
+  SESSION=$(echo "$RESULT" | awk '{print $1}')
   SESSION=${SESSION//:/}
   if [ "$SELECT_WINDOW" == "on" ]; then
     WINDOW=$(echo "$RESULT" | awk -F"[()]" '{print $(NF-1)}')

--- a/bin/t
+++ b/bin/t
@@ -13,9 +13,15 @@ if [ "$1" ]; then
   RESULT=$(z $@ && pwd)
 else
   # No argument is given. Use FZF
-  RESULT=$( (
-    tmux list-sessions -F "#{session_last_attached} #{session_name}: #{session_windows} window(s)\
-#{?session_grouped, (group ,}#{session_group}#{?session_grouped,),}#{?session_attached, (attached),}" |
+  SELECT_WINDOW=$(get_tmux_option "@session-wizard-windows" "off")
+  if [ "$SELECT_WINDOW" == "on" ]; then
+    RESULT=$(tmux list-windows -a -F "#{session_last_attached} #{session_name}: #{window_name}(#{window_index})\
+#{?session_grouped, (group ,}#{session_group}#{?session_grouped,),}#{?session_attached,#{?window_active, (attached),},}")
+  else
+    RESULT=$(tmux list-sessions -F "#{session_last_attached} #{session_name}: #{session_windows} window(s)\
+#{?session_grouped, (group ,}#{session_group}#{?session_grouped,),}#{?session_attached, (attached),}")
+  fi
+  RESULT=$( (echo "$RESULT" |
       sort -r | (if [ -n "$TMUX" ]; then grep -v " $(tmux display-message -p '#S'):"; else cat; fi) | cut -d' ' -f2-
     zoxide query -l | sed -e "$HOME_REPLACER"
   ) | $(__fzfcmd) --reverse --print-query | tail -n 1)
@@ -36,6 +42,9 @@ if [[ $RESULT == *":"* ]]; then
   # RESULT comes from list-sessions
   SESSION=$(echo $RESULT | awk '{print $1}')
   SESSION=${SESSION//:/}
+  if [ "$SELECT_WINDOW" == "on" ]; then
+    WINDOW=$(echo "$RESULT" | awk -F"[()]" '{print $(NF-1)}')
+  fi
 else
   # RESULT is a path
 
@@ -72,4 +81,8 @@ if [ -z "$TMUX" ]; then
   tmux attach -t "$SESSION"
 else
   tmux switch-client -t "$SESSION"
+fi
+
+if [ ! -z "$WINDOW" ]; then
+  tmux select-window -t "$SESSION:$WINDOW"
 fi


### PR DESCRIPTION
The format shown to the user is slightly modified, see here the difference:

Before:

    dotfiles: 2 window(s) (attached)
    thesis: 1 window(s)
    /home/user/Downloads
    ...

After:

    dotfiles/zsh (attached)
    dotfiles/tmux
    thesis/toolset
    /home/user/Downloads
    ...

This means that `RESULT` is modified as well. There is no colon in there, which means that we have to check whether the string begins with a `/`. If it does, `RESULT` is a path. If not, it must be a session. This has two downsides:

  - It might not work on Windows, since a path probably does not start with `/` on Windows. I do not know how Windows paths work (do they start with `\\`, Or with `C:\`?), and I cannot test it.

  - If the `session_name` starts with `/`, the check fails because we assume that it is a path instead. This last part I have let it slide, since the current script is also not really forgiving if the `session_name` contains a space (and another `session_name` exists with the first word as beginning as well).