### PR TITLE
Integration tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.{sh,tmux,bats}]
+indent_style = space
+indent_size = 2
+
+[t]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-[*.{sh,tmux,bats}]
+[*.{sh,tmux,bats,bash}]
 indent_style = space
 indent_size = 2
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The development environment is built with Nix and Nix's Flakes, if you have it o
 docker build --tag tmux-session-wizard:dev --file ./Dockerfile .
 ```
 
-To run the tests, just run `bats ./tests` for local development environment or `docker run --rm -it -u $(id -u):$(id -g) -v $PWD:$PWD -w $PWD tmux-session-wizard:dev bats ./tests` if you are using Docker.
+To run the tests, just run `bats -r ./tests` for local development environment or `docker run --rm -it -u $(id -u):$(id -g) -v $PWD:$PWD -w $PWD tmux-session-wizard:dev bats -r ./tests` if you are using Docker.
 
 There is also the helper script for it _./scripts/run-tests.sh_, run `./scripts/run-tests.sh -h` to get more information about usage.
 
@@ -151,13 +151,11 @@ There is also the helper script for it _./scripts/run-tests.sh_, run `./scripts/
 - ThePrimeagen's [tmux-sessionizer](https://github.com/ThePrimeagen/.dotfiles/blob/master/bin/.local/scripts/tmux-sessionizer)
 - Josh Medeski's [t-smart-tmux-session-manager](https://github.com/joshmedeski/t-smart-tmux-session-manager)
 
-
 ### Contributors 🙌
 
 <a href="https://github.com/27medkamal/tmux-session-wizard/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=27medkamal/tmux-session-wizard" />
 </a>
-
 
 ### License
 

--- a/bin/t
+++ b/bin/t
@@ -85,7 +85,7 @@ fi
 # https://github.com/tmux/tmux/blob/master/cmd-find.c#L1024C51-L1024C57
 SESSION=$(echo "$SESSION" | sed 's/^~$/\\~/')
 if [ -z "$TMUX" ]; then
-  if [ -n "$INTEGRATION_TEST" ]; then
+  if [ -n "$SESSION_WIZARD_INTEGRATION_TEST" ]; then
     echo "Running integrtion test, so not attaching to tmux session"
   else
     tmux attach -t "$SESSION"

--- a/bin/t
+++ b/bin/t
@@ -36,7 +36,7 @@ if ! tmux info &>/dev/null; then
   TMP_SESSION_DIR=$(mktemp -d)
   TMP_SESSION_NAME=$(session_name --full-path "$TMP_SESSION_DIR")
   # Allow for custom tmux config (mostly for testing)
-  if [ -n "$TMUX_CONFIG" ]; then
+  if [ -n "$SESSION_WIZARD_INTEGRATION_TEST" ]; then
     tmux -f "$TMUX_CONFIG" new-session -d -s "$TMP_SESSION_NAME" -c "$TMP_SESSION_DIR"
   else
     tmux new-session -d -s "$TMP_SESSION_NAME" -c "$TMP_SESSION_DIR"

--- a/bin/t
+++ b/bin/t
@@ -35,7 +35,13 @@ fi
 if ! tmux info &>/dev/null; then
   TMP_SESSION_DIR=$(mktemp -d)
   TMP_SESSION_NAME=$(session_name --full-path "$TMP_SESSION_DIR")
-  tmux new-session -d -s "$TMP_SESSION_NAME" -c "$TMP_SESSION_DIR"
+  # Allow for custom tmux config (mostly for testing)
+  if [ -n "$TMUX_CONFIG" ]; then
+    tmux -f "$TMUX_CONFIG" new-session -d -s "$TMP_SESSION_NAME" -c "$TMP_SESSION_DIR"
+  else
+    tmux new-session -d -s "$TMP_SESSION_NAME" -c "$TMP_SESSION_DIR"
+  fi
+
 fi
 
 # Get or create session
@@ -79,7 +85,11 @@ fi
 # https://github.com/tmux/tmux/blob/master/cmd-find.c#L1024C51-L1024C57
 SESSION=$(echo "$SESSION" | sed 's/^~$/\\~/')
 if [ -z "$TMUX" ]; then
-  tmux attach -t "$SESSION"
+  if [ -n "$INTEGRATION_TEST" ]; then
+    echo "Running integrtion test, so not attaching to tmux session"
+  else
+    tmux attach -t "$SESSION"
+  fi
 else
   tmux switch-client -t "$SESSION"
 fi

--- a/flake.lock
+++ b/flake.lock
@@ -20,18 +20,14 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707743206,
-        "narHash": "sha256-AehgH64b28yKobC/DAWYZWkJBxL/vP83vkY+ag2Hhy4=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2d627a2a704708673e56346fcb13d25344b8eaf3",
-        "type": "github"
+        "lastModified": 0,
+        "narHash": "sha256-7EXDb5WBw+d004Agt+JHC/Oyh/KTUglOaQ4MNjBbo5w=",
+        "path": "/nix/store/b2xy0gk6sd3fc8zamarfzach5f3wpkvi-source",
+        "type": "path"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
           version = "unstable";
           src = self;
           nativeBuildInputs = [ pkgs.makeWrapper ];
-          postInstall = ''
+          postInstall = /* bash */''
             substituteInPlace $target/session-wizard.tmux --replace  \$CURRENT_DIR $target
             wrapProgram $target/bin/t \
               --prefix PATH : ${

--- a/session-wizard.tmux
+++ b/session-wizard.tmux
@@ -15,6 +15,7 @@ set_default_session_wizard_options() {
   set_tmux_option "@session-wizard-height" "40"
   set_tmux_option "@session-wizard-width" "80"
   set_tmux_option "@session-wizard-mode" "directory"
+  set_tmux_option "@session-wizard-windows" "off"
 }
 
 # Multiple bindings can be set. Default binding is "T".

--- a/session-wizard.tmux
+++ b/session-wizard.tmux
@@ -14,6 +14,7 @@ set_default_session_wizard_options() {
   set_tmux_option "@session-wizard" "T"
   set_tmux_option "@session-wizard-height" "40"
   set_tmux_option "@session-wizard-width" "80"
+  set_tmux_option "@session-wizard-mode" "directory"
 }
 
 # Multiple bindings can be set. Default binding is "T".

--- a/session-wizard.tmux
+++ b/session-wizard.tmux
@@ -10,6 +10,12 @@ default_height=40
 tmux_option_session_wizard_width="@session-wizard-width"
 default_width=80
 
+set_default_session_wizard_options() {
+  set_tmux_option "@session-wizard" "T"
+  set_tmux_option "@session-wizard-height" "40"
+  set_tmux_option "@session-wizard-width" "80"
+}
+
 # Multiple bindings can be set. Default binding is "T".
 set_session_wizard_options() {
   local key_bindings
@@ -25,6 +31,7 @@ set_session_wizard_options() {
 }
 
 function main {
+  set_default_session_wizard_options
   set_session_wizard_options
 }
 main

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -15,6 +15,17 @@ get_tmux_option() {
   fi
 }
 
+# Prevents overriding user's options
+set_tmux_option() {
+  local option="$1"
+  local default_value="$2"
+  local option_value
+  option_value=$(tmux show-option -gqv "$option")
+  if [ -z "$option_value" ]; then
+    tmux set-option -g "$option" "$default_value"
+  fi
+}
+
 session_name() {
   if [ "$1" = "--directory" ]; then
     shift

--- a/tests/helpers.bats
+++ b/tests/helpers.bats
@@ -1,3 +1,4 @@
+# bats file_tags=unit
 setup() {
   bats_load_library 'bats-support'
   bats_load_library 'bats-assert'
@@ -48,4 +49,3 @@ unset() {
   run session_name --short-path "$TEST_PATH"
   assert_output "/mo/-f/-moo-foo-bar-baz"
 }
-

--- a/tests/integration/lib/bats.bash
+++ b/tests/integration/lib/bats.bash
@@ -1,3 +1,5 @@
+TEST_DIR="/tmp/tests"
+
 _stop_tmux() {
   run pgrep tmux
   if [ "$status" -eq 0 ]; then
@@ -6,9 +8,9 @@ _stop_tmux() {
 }
 
 _add_tmux_plugin() {
-  export _ZO_DATA_DIR=/tmp/zoxite
+  export _ZO_DATA_DIR="$TEST_DIR/zoxite"
   DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
-  export TMUX_CONFIG=/tmp/tmux.conf
+  export TMUX_CONFIG="$TEST_DIR/tmux.conf"
   echo "run-shell $DIR/../../session-wizard.tmux" >"$TMUX_CONFIG"
 }
 
@@ -23,15 +25,15 @@ _common_setup() {
   if [ -n "$TMUX" ]; then
     fail "Plase run these tests outisde of tmux"
   fi
-  export INTEGRATION_TEST=true
+  mkdir -p "$TEST_DIR"
+  export SESSION_WIZARD_INTEGRATION_TEST=true
   _stop_tmux
   _add_tmux_plugin
 }
 
 _common_teardown() {
   _stop_tmux
-  rm -rf /tmp/zoxite
-  rm -rf /tmp/tmux.conf
+  rm -rf "$TEST_DIR"
 }
 
 assert_tmux_running() {
@@ -44,5 +46,12 @@ assert_tmux_option_equal() {
   local expected=$2
   local actual
   actual="$(tmux show-option -gqv "$option")"
+  assert_equal "$actual" "$expected"
+}
+
+assert_tmux_session_number() {
+  local expected=$1
+  local actual
+  actual="$(tmux list-sessions | wc -l)"
   assert_equal "$actual" "$expected"
 }

--- a/tests/integration/lib/bats.bash
+++ b/tests/integration/lib/bats.bash
@@ -1,0 +1,48 @@
+_stop_tmux() {
+  run pgrep tmux
+  if [ "$status" -eq 0 ]; then
+    tmux kill-server
+  fi
+}
+
+_add_tmux_plugin() {
+  export _ZO_DATA_DIR=/tmp/zoxite
+  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+  export TMUX_CONFIG=/tmp/tmux.conf
+  echo "run-shell $DIR/../../session-wizard.tmux" >"$TMUX_CONFIG"
+}
+
+_common_setup() {
+  bats_require_minimum_version 1.5.0
+  bats_load_library 'bats-support'
+  bats_load_library 'bats-assert'
+
+  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+  PATH="$DIR/../../bin:$PATH"
+
+  if [ -n "$TMUX" ]; then
+    fail "Plase run these tests outisde of tmux"
+  fi
+  export INTEGRATION_TEST=true
+  _stop_tmux
+  _add_tmux_plugin
+}
+
+_common_teardown() {
+  _stop_tmux
+  rm -rf /tmp/zoxite
+  rm -rf /tmp/tmux.conf
+}
+
+assert_tmux_running() {
+  run pgrep tmux
+  assert_success
+}
+
+assert_tmux_option_equal() {
+  local option=$1
+  local expected=$2
+  local actual
+  actual="$(tmux show-option -gqv "$option")"
+  assert_equal "$actual" "$expected"
+}

--- a/tests/integration/lib/bats.bash
+++ b/tests/integration/lib/bats.bash
@@ -8,7 +8,7 @@ _stop_tmux() {
 }
 
 _add_tmux_plugin() {
-  export _ZO_DATA_DIR="$TEST_DIR/zoxite"
+  export _ZO_DATA_DIR="$TEST_DIR/zoxide"
   DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
   export TMUX_CONFIG="$TEST_DIR/tmux.conf"
   echo "run-shell $DIR/../../session-wizard.tmux" >"$TMUX_CONFIG"

--- a/tests/integration/lib/bats.bash
+++ b/tests/integration/lib/bats.bash
@@ -18,6 +18,8 @@ _common_setup() {
   bats_require_minimum_version 1.5.0
   bats_load_library 'bats-support'
   bats_load_library 'bats-assert'
+  # relative to the test file, not to the current directory
+  load ./lib/tmux-assert
 
   DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
   PATH="$DIR/../../bin:$PATH"
@@ -34,24 +36,4 @@ _common_setup() {
 _common_teardown() {
   _stop_tmux
   rm -rf "$TEST_DIR"
-}
-
-assert_tmux_running() {
-  run pgrep tmux
-  assert_success
-}
-
-assert_tmux_option_equal() {
-  local option=$1
-  local expected=$2
-  local actual
-  actual="$(tmux show-option -gqv "$option")"
-  assert_equal "$actual" "$expected"
-}
-
-assert_tmux_session_number() {
-  local expected=$1
-  local actual
-  actual="$(tmux list-sessions | wc -l)"
-  assert_equal "$actual" "$expected"
 }

--- a/tests/integration/lib/tmux-assert.bash
+++ b/tests/integration/lib/tmux-assert.bash
@@ -1,0 +1,26 @@
+assert_tmux_running() {
+  run pgrep tmux
+  assert_success
+}
+
+assert_tmux_option_equal() {
+  local option=$1
+  local expected=$2
+  local actual
+  actual="$(tmux show-option -gqv "$option")"
+  assert_equal "$actual" "$expected"
+}
+
+assert_tmux_sessions_number() {
+  local expected=$1
+  local actual
+  actual="$(tmux list-sessions | wc -l)"
+  assert_equal "$actual" "$expected"
+}
+
+assert_tmux_session_exists() {
+  local session_name=$1
+  output="$(tmux list-sessions -F "#{session_name}")"
+  assert_output "$session_name"
+}
+  

--- a/tests/integration/session.bats
+++ b/tests/integration/session.bats
@@ -13,16 +13,15 @@ teardown() {
   assert_tmux_option_equal "@session-wizard-mode" "directory"
 }
 
-assert_session_name() {
+verify_session_name() {
   local dir="$1"
   local expected_session_name="$2"
   mkdir -p "$dir"
   # Run session-wizard
   t "$dir"
   # Check if session was created with expected name
-  assert_tmux_session_number 1
-  session_name="$(tmux list-sessions -F "#{session_name}")"
-  assert_equal "$session_name" "$expected_session_name"
+  assert_tmux_sessions_number 1
+  assert_tmux_session_exists "$expected_session_name"
   # Cleanup
   _stop_tmux
 }
@@ -37,7 +36,7 @@ assert_session_name() {
 
   for expected_session_name in "${!test_data[@]}"; do
     dir="${test_data[${expected_session_name}]}"
-    assert_session_name "$dir" "$expected_session_name"
+    verify_session_name "$dir" "$expected_session_name"
   done
 }
 
@@ -53,7 +52,7 @@ assert_session_name() {
 
   for expected_session_name in "${!test_data[@]}"; do
     dir="${test_data[${expected_session_name}]}"
-    assert_session_name "$dir" "$expected_session_name"
+    verify_session_name "$dir" "$expected_session_name"
   done
 }
 
@@ -69,22 +68,22 @@ assert_session_name() {
 
   for expected_session_name in "${!test_data[@]}"; do
     dir="${test_data[${expected_session_name}]}"
-    assert_session_name "$dir" "$expected_session_name"
+    verify_session_name "$dir" "$expected_session_name"
   done
 }
 
 @test "Run session-wizzard twice with the same directory should create ONLY one session" {
   mkdir -p "$TEST_DIR/dir"
   t "$TEST_DIR/dir"
-  assert_tmux_session_number 1
+  assert_tmux_sessions_number 1
   t "$TEST_DIR/dir"
-  assert_tmux_session_number 1
+  assert_tmux_sessions_number 1
 }
 @test "Run session-wizzard twice with different directory should create two sessions" {
   mkdir -p "$TEST_DIR/dir1"
   mkdir -p "$TEST_DIR/dir2"
   t "$TEST_DIR/dir1"
-  assert_tmux_session_number 1
+  assert_tmux_sessions_number 1
   t "$TEST_DIR/dir2"
-  assert_tmux_session_number 2
+  assert_tmux_sessions_number 2
 }

--- a/tests/integration/session.bats
+++ b/tests/integration/session.bats
@@ -1,0 +1,75 @@
+# bats file_tags=integration
+setup() {
+  load ./lib/bats.bash
+  _common_setup
+}
+
+teardown() {
+  _common_teardown
+}
+
+@test "'directory' is default mode" {
+  t .
+  assert_tmux_option_equal "@session-wizard-mode" "directory"
+}
+
+assert_session_name() {
+  local dir="$1"
+  local expected_session_name="$2"
+  mkdir -p "$dir"
+  # Run session-wizard
+  t "$dir"
+  # Check if session was created with expected name
+  sessions_counter=$(tmux list-sessions | wc -l)
+  assert_equal 1 "$sessions_counter"
+  session_name="$(tmux list-sessions -F "#{session_name}")"
+  assert_equal "$session_name" "$expected_session_name"
+  # Cleanup
+  _stop_tmux
+}
+
+@test "Session name for 'directory' mode should be normalized directory name" {
+  declare -A test_data
+  test_data=(
+    ["dir"]="/tmp/dir"
+    ["dir-2"]="/tmp/dir.2"
+    ["dir_3"]="/tmp/DIR_3"
+  )
+
+  for expected_session_name in "${!test_data[@]}"; do
+    dir="${test_data[${expected_session_name}]}"
+    assert_session_name "$dir" "$expected_session_name"
+  done
+}
+
+@test "Session name for 'full-path' mode should be normalized full path" {
+  declare -A test_data
+  test_data=(
+    ["/tmp/dir"]="/tmp/dir"
+    ["/tmp/dir-2"]="/tmp/dir.2"
+    ["/tmp/dir_3"]="/tmp/DIR_3"
+  )
+  echo "set -g @session-wizard-mode 'full-path'" >>"$TMUX_CONFIG"
+  HOME="/tmp/home"
+
+  for expected_session_name in "${!test_data[@]}"; do
+    dir="${test_data[${expected_session_name}]}"
+    assert_session_name "$dir" "$expected_session_name"
+  done
+}
+
+@test "Session name for 'short-path' mode should be normalized short path" {
+  declare -A test_data
+  test_data=(
+    ["/tm/dir"]="/tmp/dir"
+    ["/tm/dir-2"]="/tmp/dir.2"
+    ["/tm/-h/dir_3"]="/tmp/.hidden/DIR_3"
+  )
+  echo "set -g @session-wizard-mode 'short-path'" >>"$TMUX_CONFIG"
+  HOME="/tmp/home"
+
+  for expected_session_name in "${!test_data[@]}"; do
+    dir="${test_data[${expected_session_name}]}"
+    assert_session_name "$dir" "$expected_session_name"
+  done
+}

--- a/tests/integration/session.bats
+++ b/tests/integration/session.bats
@@ -20,8 +20,7 @@ assert_session_name() {
   # Run session-wizard
   t "$dir"
   # Check if session was created with expected name
-  sessions_counter=$(tmux list-sessions | wc -l)
-  assert_equal 1 "$sessions_counter"
+  assert_tmux_session_number 1
   session_name="$(tmux list-sessions -F "#{session_name}")"
   assert_equal "$session_name" "$expected_session_name"
   # Cleanup
@@ -31,9 +30,9 @@ assert_session_name() {
 @test "Session name for 'directory' mode should be normalized directory name" {
   declare -A test_data
   test_data=(
-    ["dir"]="/tmp/dir"
-    ["dir-2"]="/tmp/dir.2"
-    ["dir_3"]="/tmp/DIR_3"
+    ["dir"]="$TEST_DIR/dir"
+    ["dir-2"]="$TEST_DIR/dir.2"
+    ["dir_3"]="$TEST_DIR/DIR_3"
   )
 
   for expected_session_name in "${!test_data[@]}"; do
@@ -45,9 +44,9 @@ assert_session_name() {
 @test "Session name for 'full-path' mode should be normalized full path" {
   declare -A test_data
   test_data=(
-    ["/tmp/dir"]="/tmp/dir"
-    ["/tmp/dir-2"]="/tmp/dir.2"
-    ["/tmp/dir_3"]="/tmp/DIR_3"
+    ["$TEST_DIR/dir"]="$TEST_DIR/dir"
+    ["$TEST_DIR/dir-2"]="$TEST_DIR/dir.2"
+    ["$TEST_DIR/dir_3"]="$TEST_DIR/DIR_3"
   )
   echo "set -g @session-wizard-mode 'full-path'" >>"$TMUX_CONFIG"
   HOME="/tmp/home"
@@ -61,9 +60,9 @@ assert_session_name() {
 @test "Session name for 'short-path' mode should be normalized short path" {
   declare -A test_data
   test_data=(
-    ["/tm/dir"]="/tmp/dir"
-    ["/tm/dir-2"]="/tmp/dir.2"
-    ["/tm/-h/dir_3"]="/tmp/.hidden/DIR_3"
+    ["/tm/te/dir"]="/tmp/tests/dir"
+    ["/tm/te/dir-2"]="/tmp/tests/dir.2"
+    ["/tm/te/-h/dir_3"]="/tmp/tests/.hidden/DIR_3"
   )
   echo "set -g @session-wizard-mode 'short-path'" >>"$TMUX_CONFIG"
   HOME="/tmp/home"
@@ -72,4 +71,20 @@ assert_session_name() {
     dir="${test_data[${expected_session_name}]}"
     assert_session_name "$dir" "$expected_session_name"
   done
+}
+
+@test "Run session-wizzard twice with the same directory should create ONLY one session" {
+  mkdir -p "$TEST_DIR/dir"
+  t "$TEST_DIR/dir"
+  assert_tmux_session_number 1
+  t "$TEST_DIR/dir"
+  assert_tmux_session_number 1
+}
+@test "Run session-wizzard twice with different directory should create two sessions" {
+  mkdir -p "$TEST_DIR/dir1"
+  mkdir -p "$TEST_DIR/dir2"
+  t "$TEST_DIR/dir1"
+  assert_tmux_session_number 1
+  t "$TEST_DIR/dir2"
+  assert_tmux_session_number 2
 }

--- a/tests/integration/tmux.bats
+++ b/tests/integration/tmux.bats
@@ -1,43 +1,12 @@
 # bats file_tags=integration
-_stop_tmux() {
-  run pgrep tmux
-  if [ "$status" -eq 0 ]; then
-    tmux kill-server
-  fi
-}
-
-_add_tmux_plugin() {
-  export _ZO_DATA_DIR=/tmp/zoxite
-  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
-  echo "run-shell $DIR/../../session-wizard.tmux" >/tmp/tmux.conf
-  export TMUX_CONFIG=/tmp/tmux.conf
-}
-
+#
 setup() {
-  bats_require_minimum_version 1.5.0
-  bats_load_library 'bats-support'
-  bats_load_library 'bats-assert'
-
-  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
-  PATH="$DIR/../../bin:$PATH"
-
-  if [ -n "$TMUX" ]; then
-    fail "Plase run these tests outisde of tmux"
-  fi
-  export INTEGRATION_TEST=true
-  _stop_tmux
-  _add_tmux_plugin
-}
-
-assert_tmux_running() {
-  run pgrep tmux
-  assert_success
+  load ./lib/bats.bash
+  _common_setup
 }
 
 teardown() {
-  _stop_tmux
-  rm -rf /tmp/zoxite
-  rm -rf /tmp/tmux.conf
+  _common_teardown
 }
 
 @test "Can run 't' with loaded plugin" {

--- a/tests/integration/tmux.bats
+++ b/tests/integration/tmux.bats
@@ -1,0 +1,60 @@
+# bats file_tags=integration
+_stop_tmux() {
+  run pgrep tmux
+  if [ "$status" -eq 0 ]; then
+    tmux kill-server
+  fi
+}
+
+_add_tmux_plugin() {
+  export _ZO_DATA_DIR=/tmp/zoxite
+  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+  echo "run-shell $DIR/../../session-wizard.tmux" >/tmp/tmux.conf
+  export TMUX_CONFIG=/tmp/tmux.conf
+}
+
+setup() {
+  bats_require_minimum_version 1.5.0
+  bats_load_library 'bats-support'
+  bats_load_library 'bats-assert'
+
+  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+  PATH="$DIR/../../bin:$PATH"
+
+  if [ -n "$TMUX" ]; then
+    fail "Plase run these tests outisde of tmux"
+  fi
+  export INTEGRATION_TEST=true
+  _stop_tmux
+  _add_tmux_plugin
+}
+
+assert_tmux_running() {
+  run pgrep tmux
+  assert_success
+}
+
+teardown() {
+  _stop_tmux
+  rm -rf /tmp/zoxite
+  rm -rf /tmp/tmux.conf
+}
+
+@test "Can run 't' with loaded plugin" {
+  t .
+  assert_tmux_running
+  # Checking default key binding for session wizard plugin
+  option=$(tmux show-option -gqv @session-wizard)
+  assert_equal "$option" "T"
+}
+
+@test "Can overwrite default options" {
+  echo "set-option -g @session-wizard 't'" >>/tmp/tmux.conf
+  t .
+  assert_tmux_running
+  # Checking default key binding for session wizard plugin
+  option=$(tmux show-option -gqv @session-wizard-width)
+  assert_equal "$option" "80"
+  option=$(tmux show-option -gqv @session-wizard)
+  assert_equal "$option" "t"
+}

--- a/tests/integration/tmux.bats
+++ b/tests/integration/tmux.bats
@@ -18,7 +18,7 @@ teardown() {
 }
 
 @test "Can overwrite default options" {
-  echo "set-option -g @session-wizard 't'" >>/tmp/tmux.conf
+  echo "set-option -g @session-wizard 't'" >>"$TEST_DIR/tmux.conf"
   t .
   assert_tmux_running
   # Checking default key binding for session wizard plugin

--- a/tests/integration/tmux.bats
+++ b/tests/integration/tmux.bats
@@ -12,18 +12,20 @@ teardown() {
 @test "Can run 't' with loaded plugin" {
   t .
   assert_tmux_running
-  # Checking default key binding for session wizard plugin
+  # Checking default key binding for plugin (basic test if plugin is loaded)
   option=$(tmux show-option -gqv @session-wizard)
   assert_equal "$option" "T"
 }
 
 @test "Can overwrite default options" {
+  # Change default binding for plugin
   echo "set-option -g @session-wizard 't'" >>"$TEST_DIR/tmux.conf"
   t .
   assert_tmux_running
-  # Checking default key binding for session wizard plugin
+  # Checking default option for plugin
   option=$(tmux show-option -gqv @session-wizard-width)
   assert_equal "$option" "80"
+  # Checking  new binding for plugin
   option=$(tmux show-option -gqv @session-wizard)
   assert_equal "$option" "t"
 }


### PR DESCRIPTION
@27medkamal before implementing the duplicate session feature (#10) I would like to clean up code a bit (especially 't' binary) and introduce tests to verify the plugin's behavior real tmux and zoxide. 

This  commit introduces a proposal of integration test that are executed in Docker.

**Test Scenario**
Each integration test follows these steps:

- Stop tmux server if exists
- set up a tmux configuration in '/tmp/tmux.conf' with the plugin initialization
- Run the test (tmux session is detached)
- Clean up: remove zoxide and tmux files, and stop tmux server

**Additional Environment Variables:**
Two new environment variables are used to facilitate the tests:

- TMUX_CONFIG - Specifies the path to the configuration file. If unset, tmux will use the default configuration.
- INTEGRATION_TEST - A flag to prevent session attachment. All tests are executed outside tmux.

Please review and share your thoughts.